### PR TITLE
Add Github Actions for tests and releases

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -1,0 +1,31 @@
+name: Go Testing
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+jobs:
+  golangci:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v1
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.29
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go >= 1.14
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.14
+        id: go
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+      - name: Get dependencies
+        run: go mod download
+      - name: Test
+        run: go test -v -covermode=count ./...

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,25 @@
+name: Release Artifacts
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  goreleaser:
+    name: Release Binaries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/version/git_test.go
+++ b/version/git_test.go
@@ -15,6 +15,7 @@ func TestGitDescribe(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(dir)
-	os.Chdir(dir)
+	err = os.Chdir(dir)
+	assert.NoError(err)
 	assert.Equal("0.0.0-0-", git.Describe())
 }


### PR DESCRIPTION
The goreleaser produces something like this:
![goreleaser](https://user-images.githubusercontent.com/1129075/89347179-902eec00-d6aa-11ea-9876-4d43aee8af74.PNG)

by just creating a git tag.

The other actions are the golangci-linter and the go tests, but not the codecov.
