### PR TITLE
Reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM golang:1.14-alpine3.12 as builder
 COPY . /go/src/github.com/mdomke/git-semver
-RUN go install github.com/mdomke/git-semver
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go install github.com/mdomke/git-semver
 
-FROM docker:18-git
+FROM alpine:3.12
+RUN apk add --update --no-cache git
 COPY --from=builder /go/bin/git-semver /usr/local/bin/
-RUN mkdir /git-semver
 WORKDIR /git-semver
 ENTRYPOINT ["git-semver"]


### PR DESCRIPTION
Maybe I am missing something, but it looks like the only things needed inside the docker image are git and the program itself. This PR reduces the docker images size from 374MB down to 25MB.

Note: The best would be a scratch image with the program as only binary and that does not invoke git but instead uses go-git for example to do the git describe. But sadly go-git does not support describing yet.