### PR TITLE
Additional flags to bump major/minor/patch parts

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,6 +16,9 @@ var setMeta = flag.String("set-meta", "", "set build metadata (default: none)")
 var excludePreRelease = flag.Bool("no-pre", false, "exclude pre-release version (default: false)")
 var excludePatch = flag.Bool("no-patch", false, "exclude pre-release version (default: false)")
 var excludeMinor = flag.Bool("no-minor", false, "exclude pre-release version (default: false)")
+var nextMajor = flag.Bool("next-major", false, "increase major version (default: false)")
+var nextMinor = flag.Bool("next-minor", false, "increase minor version (default: false)")
+var nextPatch = flag.Bool("next-patch", false, "increase patch version (default: false)")
 
 func init() {
 	flag.Usage = func() {
@@ -66,7 +69,12 @@ func main() {
 	if *prefix != "" {
 		v.Prefix = *prefix
 	}
-	s, err := v.Format(selectFormat())
+	bumpOptions := version.BumpOptions{
+		IncreaseMajor: *nextMajor,
+		IncreaseMinor: *nextMinor,
+		IncreasePatch: *nextPatch,
+	}
+	s, err := v.Format(selectFormat(), bumpOptions)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)


### PR DESCRIPTION
This PR adds the new flags `-next-major`, `-next-minor` and `-next-patch` to increment major/minor/patch parts of the version respectively.

Usage example:
```
$ git-semver
v6.0.1
$ git-semver -next-major
v7.0.0
$ git-semver -next-minor
v6.1.0
$ git-semver -next-patch
v6.0.2
```

Will update the documentation and add missing tests if you are fine with this implementation and idea.