### PR TITLE
fix: grab <repo> arg from our FlagSet not the global one

### DIFF
--- a/main.go
+++ b/main.go
@@ -123,5 +123,11 @@ func main() {
 		}
 		os.Exit(2)
 	}
-	os.Exit(handle(cfg, flag.Arg(0)))
+
+	var path string
+
+	if len(cfg.args) > 0 {
+		path = cfg.args[0]
+	}
+	os.Exit(handle(cfg, path))
 }


### PR DESCRIPTION
Command line argument parsing is creating a NewFlagSet but is passing the first argument from the `flag` package's global FlagSet which is not attached to the argument vector.

To verify this

```
go build .; cd version; ../git-semver ..; cd ..
```

before: `failed to open repo: repository does not exist`
aftter:  `v6.1.1-dev.1+e256c2b1`
