### PR TITLE
Switching git.PlainOpen for git.PlainOpenWithOptions so that git-semver can be called from a subdirectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.8.1] - ?
+### Fixed
+* An error was issued when invoked from subfolder of the repository whereas `git-describe` ususally succeeds in such cases.
+
 ## [6.8.0] - 2023-09-22
 ### Added
 * New flag `-match` that can be used to select only specific tags matching a glob pattern into the

--- a/version/git.go
+++ b/version/git.go
@@ -50,7 +50,8 @@ func GitDescribe(path string, opts ...Option) (*RepoHead, error) {
 		apply(&options)
 	}
 
-	repo, err := git.PlainOpen(path)
+	openOpts := git.PlainOpenOptions{DetectDotGit: true}
+	repo, err := git.PlainOpenWithOptions(path, &openOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open repo: %w", err)
 	}

--- a/version/git_test.go
+++ b/version/git_test.go
@@ -99,6 +99,16 @@ func TestGitDescribe(t *testing.T) {
 		Hash:            commit2.String(),
 		CommitsSinceTag: 0,
 	})
+
+	dir += "/subfoler"
+	err = os.Mkdir(dir, 0750)
+	assert.NoError(err)
+
+	test(&RepoHead{
+		LastTag:         tag3.Name().Short(),
+		Hash:            commit2.String(),
+		CommitsSinceTag: 0,
+	})
 }
 
 func TestGitDescribeError(t *testing.T) {


### PR DESCRIPTION
- [x] Changelog updated
- [x] Unit test added
- [ ] ~~Documentation updated~~

To me it fixes a bug because git describe works by default when walled from a subdirectory of the repository and git-semver did not. The documentation did not specify whether git-semver was intended to have the same behavior or not, so I left it unchanged.

Closes #33