### PR TITLE
Fix bad git-min alias resolves tag permanently

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
    ```
   or create an alias
    ```bash
-   alias gtg-min="git tag -s -a $(git-semver -target minor)"  
+   alias gtg-min='git tag -s -a $(git-semver -target minor)'
    ```
 
 ## Why is this useful?


### PR DESCRIPTION
With the `gtg-min` alias, using double-quotes calls git-semver immediately and encodes the current tag permanently in the alias. Then, every time you call the alias, it uses the same tag and fails with `fatal: tag 'x.y.z' already exists`.

We change it to single quotes so that the subcommand is not resolved at definition and calling the alias will generate a new tag every time.

Fixes #43